### PR TITLE
Added missing recycle in DominoStorageService

### DIFF
--- a/org.openntf.xpt.core/src/org/openntf/xpt/core/dss/DominoStorageService.java
+++ b/org.openntf.xpt.core/src/org/openntf/xpt/core/dss/DominoStorageService.java
@@ -171,6 +171,7 @@ public class DominoStorageService {
 			Document docCurrent = getDocument(ds, obj, ndbTarget, true, objID);
 			j2d.processDocument(docCurrent, obj, "" + objID);
 			docCurrent.save(true, false, true);
+			docCurrent.recycle();
 		} catch (Exception e) {
 			e.printStackTrace();
 			return false;


### PR DESCRIPTION
Hi

There was a memory leak in the DominoStorageService. The save/saveTo methods did not recycle their created Documents. Document should never be null according to previous code, so no null check, just a simple Document recycle.

Hope you like the change